### PR TITLE
Add optional RUNTIME_VERSIONS parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,7 @@ A github action to install the latest daily build of the .NET SDK.
     # version band of the .NET SDK to look for the newest version on in the feeds (optional, default is '1xx').
     # for different values look in the dotnet/installer github repository.
     VERSION_BAND: '1xx'
+    # The list of versions of the runtime to install.
+    # The value below is the default list.
+    RUNTIME_VERSIONS: '1.0.16;1.1.13;2.0.9;2.1.30;2.2.8;3.0.3;3.1.29;5.0.17;6.0.10'
 ```

--- a/action.yml
+++ b/action.yml
@@ -16,7 +16,7 @@ inputs:
         required: false
         default: '1xx'
     RUNTIME_VERSIONS:
-        description: 
+        description: The list of versions of the runtime to install.
         required: false
         # 7.0.0-rc2 currently lacks 6.0.10 because it's in preview.
         # Versions under 6.0.x are EOL but some projects may need them.

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,12 @@ inputs:
         description: Band version of the .NET SDK to install.
         required: false
         default: '1xx'
+    RUNTIME_VERSIONS:
+        description: 
+        required: false
+        # 7.0.0-rc2 currently lacks 6.0.10 because it's in preview.
+        # Versions under 6.0.x are EOL but some projects may need them.
+        default: '1.0.16;1.1.13;2.0.9;2.1.30;2.2.8;3.0.3;3.1.29;5.0.17;6.0.10'
 
 runs:
     using: node12

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ class Action
         this.versionMajor = process.env.INPUT_VERSION_MAJOR
         this.versionMinor = process.env.INPUT_VERSION_MINOR
         this.versionBand = process.env.INPUT_VERSION_BAND
+        this.runtimeVersions = process.env.RUNTIME_VERSIONS
     }
 
     _printErrorAndExit(msg)
@@ -31,6 +32,11 @@ class Action
         {
             // Windows.
             this._executeCommand(`pwsh ${__dirname}/dotnet-install.ps1 -Channel ${this.versionMajor}.${this.versionMinor}.${this.versionBand} -Quality daily`, { encoding: "utf-8", stdio: [process.stdin, process.stdout, process.stderr] })
+            // Install the runtimes from the list of runtimes.
+            for (let runtimeVersion of this.runtimeVersions)
+            {
+                this._executeCommand(`pwsh ${__dirname}/dotnet-install.ps1 -Version ${runtimeVersion} -Runtime dotnet -Runtime aspnetcore`, { encoding: "utf-8", stdio: [process.stdin, process.stdout, process.stderr] })
+            }
             if (!process.env['DOTNET_INSTALL_DIR'])
             {
                 // This is the default set in install-dotnet.ps1
@@ -42,6 +48,11 @@ class Action
         {
             // Linux and MacOS.
             this._executeCommand(`${__dirname}/dotnet-install.sh --channel ${this.versionMajor}.${this.versionMinor}.${this.versionBand} --quality daily`, { encoding: "utf-8", stdio: [process.stdin, process.stdout, process.stderr] })
+            // Install the runtimes from the list of runtimes.
+            for (let runtimeVersion of this.runtimeVersions)
+            {
+                this._executeCommand(`${__dirname}/dotnet-install.sh --version ${runtimeVersion} --runtime dotnet --runtime aspnetcore`, { encoding: "utf-8", stdio: [process.stdin, process.stdout, process.stderr] })
+            }
             if (!process.env['DOTNET_INSTALL_DIR'])
             {
                 // This is the default set in install-dotnet.sh


### PR DESCRIPTION
Fixes https://github.com/Elskom/setup-latest-dotnet/issues/5